### PR TITLE
Improve error message when an API key has not been added by the user

### DIFF
--- a/includes/Modal/OpenAi_Generator.php
+++ b/includes/Modal/OpenAi_Generator.php
@@ -52,8 +52,8 @@ class OpenAi_Generator {
 	 */
 	public function generate( WC_Product $product ) {
 		$settings = $this->settings->get_settings();
-		if ( ! is_array( $settings ) || ! isset( $settings['openai_api_key'] ) ) {
-			throw new Exception( __( 'Please enter your OpenAI API key in the CopyCraft settings.', 'copycraft' ) );
+		if ( ! is_array( $settings ) || 0 === strlen( $settings['openai_api_key'] ) ) {
+			throw new Exception( __( 'Please enter your OpenAI API key in the CopyCraft settings and try again.', 'copycraft' ) );
 		}
 
 		$prompt = $this->build_prompt( $product );

--- a/includes/Modal/Screen.php
+++ b/includes/Modal/Screen.php
@@ -109,7 +109,7 @@ class Screen {
 	}
 
 	/**
-	 * Output the HTML content that is displayed in the modal.
+	 * AJAX handler that outputs the HTML content that is then displayed in the modal.
 	 *
 	 * @return void
 	 */
@@ -141,13 +141,9 @@ class Screen {
 			echo '<button id="insert" class="button button-primary button-large" title="' . esc_attr__( 'Append this new description to the existing description.', 'copycraft' ) . '">' . esc_html__( 'Insert', 'copycraft' ) . '</button>';
 			echo '<button id="refresh" class="button button-primary button-large" title="' . esc_attr__( 'Generate a new description.', 'copycraft' ) . '">' . esc_html__( 'Try again', 'copycraft' ) . '</button>';
 			echo '<button id="discard" class="button button-primary button-large" title="' . esc_attr__( 'Return to the Edit Produt screen.', 'copycraft' ) . '">' . esc_html__( 'Discard', 'copycraft' ) . '</button>';
-
+			echo '</div>';
 		} catch ( Exception $e ) {
-			// TODO: log this error instead of outputting it.
-			echo '<pre>' . esc_html( $e->getMessage() ) . '</pre>';
-			$this->error( __( 'An unexpected error occurred. Please try again.', 'copycraft' ) );
-		} finally {
-			exit;
+			$this->error( esc_html( $e->getMessage() ) );
 		}
 	}
 


### PR DESCRIPTION
Instead of showing:

> OpenAI API Error: Unsuccessful response. HTTP status code: 401 (Unauthorized).

the modal now shows:

> Please enter your OpenAI API key in the CopyCraft settings and try again.