### PR TITLE
Use array as output from `tectalic/openai` package 

### DIFF
--- a/includes/Modal/OpenAi_Generator.php
+++ b/includes/Modal/OpenAi_Generator.php
@@ -8,8 +8,6 @@ use OM4\CopyCraft\Vendor\Tectalic\OpenAi\Client as OpenAiClient;
 use OM4\CopyCraft\Vendor\Tectalic\OpenAi\ClientException;
 use OM4\CopyCraft\Vendor\Tectalic\OpenAi\Models\Completions\CreateRequest as CompletionsRequest;
 use OM4\CopyCraft\Vendor\Tectalic\OpenAi\Models\Moderations\CreateRequest as ModerationsRequest;
-use OM4\CopyCraft\Vendor\Tectalic\OpenAi\Models\Completions\CreateResponse as CompletionsResponse;
-use OM4\CopyCraft\Vendor\Tectalic\OpenAi\Models\Moderations\CreateResponse as ModerationsResponse;
 use WC_Product;
 
 /**
@@ -69,15 +67,15 @@ class OpenAi_Generator {
 				// Moderate the prompt, and store the result flag in a transient.
 
 				/**
-				 * The Moderations API Call Response model.
+				 * The Moderations API Call Response.
 				 *
-				 * @var ModerationsResponse $result
+				 * @var array $result
 				 */
 				$result = $this->client->moderations()->create(
 					new ModerationsRequest( array( 'input' => $prompt ) )
-				)->toModel();
+				)->toArray();
 
-				$flagged = (int) $result->results[0]->flagged;
+				$flagged = (int) $result['results'][0]['flagged'];
 				set_transient( $key, $flagged, DAY_IN_SECONDS );
 			}
 
@@ -93,9 +91,9 @@ class OpenAi_Generator {
 			// Generate the product description using the OpenAI completions API.
 			$completions = $this->client->completions();
 			/**
-			 * The Completions API Call Response Model instance.
+			 * The Completions API Call Response.
 			 *
-			 * @var CompletionsResponse $result
+			 * @var array $result
 			 */
 			$result          = $completions->create(
 				new CompletionsRequest(
@@ -106,21 +104,21 @@ class OpenAi_Generator {
 						'max_tokens'  => 2000,
 					)
 				)
-			)->toModel();
-			$new_description = $result->choices[0]->text;
+			)->toArray();
+			$new_description = $result['choices'][0]['text'];
 
 			// Moderate the result.
 
 			/**
-			 * The Moderation API Call Response Model instance.
+			 * The Moderation API Call Response.
 			 *
-			 * @var ModerationsResponse $result
+			 * @var array $result
 			 */
 			$result = $this->client->moderations()->create(
 				new ModerationsRequest( array( 'input' => $new_description ) )
-			)->toModel();
+			)->toArray();
 
-			if ( $result->results[0]->flagged ) {
+			if ( $result['results'][0]['flagged'] ) {
 				throw new Exception(
 					__(
 						'This generated description contains content that does not comply with OpenAI\'s content policy. Please edit the product description manually.',

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,7 @@ parameters:
 	fileExtensions:
 		- php
 	level: max
+	checkMissingIterableValueType: false
 	bootstrapFiles:
 		- vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
 		- vendor/php-stubs/woocommerce-stubs/woocommerce-packages-stubs.php


### PR DESCRIPTION
Reason

As a misguided attempt (in 2023) to speed up php runtime, some PHP hosts are stripping comments from PHP files in production servers. Unfortunately, this configuration effectively broke any php code dependent on the Reflection API used on docblocks. It includes, amongst many other packages, the `symfony/routing`, `doctrine/dbal`, Laravel and so on.

The `tectalic/openai` package uses `spatie/data-transfer-object` to handle the casting (validation) of input and output of the library. Because it supports PHP 7.x versions, which have limited type support, the casting depends on docblock information.

Fortunately, there is a solution at the expense of catching some of the input/output errors: That library also works with plain old associated arrays.

Also: The side effect was that the PHPStan tool lost the knowledge of the structure of the results. So without defining it again, the solution is to relax the checking, hence introducing the `checkMissingIterableValueType: false` config.
