### PR TITLE
Replace `expect-puppeteer` matchers with own

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   preset: 'jest-puppeteer',
+  setupFilesAfterEnv: ['./tests/setup.js'],
   testTimeout: 20_000 // 20 second
 };

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -95,4 +95,4 @@ We use the following tools to write e2e tests:
 - Use WordPress' [E2E Test Utils](https://www.npmjs.com/package/@wordpress/e2e-test-utils) API, to navigate between pages. It is pre-configured to work seamlessly with `wp-env`.
 - Use [Puppeteer](https://github.com/GoogleChrome/puppeteer) directly interact with the page.
 
-Note: Do not use [expect-puppeteer](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer) API. The time of writing appears to be broken, even with `puppeteer@17` installed.
+Note: Do not use [expect-puppeteer API](https://github.com/smooth-code/jest-puppeteer/blob/master/packages/expect-puppeteer/README.md#api). At the time of writing appears to be broken, even with `puppeteer@17` installed. Instead, use the matchers provided in `tests/expect-matchers.js` instead.

--- a/tests/e2e/admin.test.js
+++ b/tests/e2e/admin.test.js
@@ -6,6 +6,6 @@ describe('Store Owner', () => {
     expect.assertions(1);
 
     await visitAdminPage('/');
-    await expect(page).toMatchElement('#welcome-panel > div > div.welcome-panel-header > h2', 'Welcome to WordPress');
+    await expect(page).toElementEquals('#welcome-panel > div > div.welcome-panel-header > h2', 'Welcome to WordPress!');
   });
 });

--- a/tests/e2e/plugins.test.js
+++ b/tests/e2e/plugins.test.js
@@ -7,6 +7,6 @@ describe('Plugins Screen', () => {
     expect.assertions(1);
 
     await visitAdminPage('plugins.php', 'plugin_status=active');
-    await expect(page).toMatchElement('tr[data-slug="copycraft"] .plugin-title strong', { text: 'CopyCraft' });
+    await expect(page).toElementEquals('tr[data-slug="copycraft"] .plugin-title strong', 'CopyCraft');
   });
 });

--- a/tests/e2e/products.test.js
+++ b/tests/e2e/products.test.js
@@ -19,7 +19,7 @@ describe('Product Management', () => {
     // Verify new page saved.
     await expect(page).toElementEquals('#wpbody-content > div.wrap > h1', 'Edit product');
     await expect(page).toElementEquals('#title', 'Draft Product');
-    await expect(page).toIncludes('Product draft updated.');
+    await expect(page).toIncludeText('Product draft updated.');
   });
   it('Can create a new published product', async () => {
     expect.assertions(4);
@@ -33,7 +33,7 @@ describe('Product Management', () => {
     // Verify new page saved.
     await expect(page).toElementEquals('#wpbody-content > div.wrap > h1', 'Edit product');
     await expect(page).toElementEquals('#title', 'Published Product');
-    await expect(page).toIncludes('Product published.');
+    await expect(page).toIncludeText('Product published.');
   });
   it('Page load correctly', async () => {
     expect.assertions(3);
@@ -73,10 +73,10 @@ describe('Product Management', () => {
       '#copycraft-modal-contents p.error',
       'Please enter a product name and try again.'
     );
-    await expect(page).not.toHasElement('#replace');
-    await expect(page).not.toHasElement('#insert');
-    await expect(page).not.toHasElement('#refresh');
-    await expect(page).not.toHasElement('#discard');
+    await expect(page).not.toHaveElement('#replace');
+    await expect(page).not.toHaveElement('#insert');
+    await expect(page).not.toHaveElement('#refresh');
+    await expect(page).not.toHaveElement('#discard');
   });
   it('Modal displays and ajax request running', async () => {
     expect.assertions(2);

--- a/tests/e2e/products.test.js
+++ b/tests/e2e/products.test.js
@@ -22,7 +22,7 @@ describe('Product Management', () => {
     await expect(page).toIncludes('Product draft updated.');
   });
   it('Can create a new published product', async () => {
-    expect.assertions(5);
+    expect.assertions(4);
 
     // Enter a Product Title
     await expect(page).toFillElement('#title', 'Published Product');
@@ -33,8 +33,7 @@ describe('Product Management', () => {
     // Verify new page saved.
     await expect(page).toElementEquals('#wpbody-content > div.wrap > h1', 'Edit product');
     await expect(page).toElementEquals('#title', 'Published Product');
-    await expect(page).toIncludes('Product draft updated.');
-    await expect(page).toMatch('Product published.');
+    await expect(page).toIncludes('Product published.');
   });
   it('Page load correctly', async () => {
     expect.assertions(3);
@@ -119,7 +118,7 @@ describe('Product Management', () => {
     await page.waitForSelector('#copycraft-modal-contents p.error');
     await expect(page).toElementEquals(
       '#copycraft-modal-contents p.error',
-      'Please enter a product name and try agadadsvavdssain.'
+      'Please enter your OpenAI API key in the CopyCraft settings and try again.'
     );
   });
 });

--- a/tests/e2e/products.test.js
+++ b/tests/e2e/products.test.js
@@ -11,35 +11,36 @@ describe('Product Management', () => {
     expect.assertions(4);
 
     // Enter a Product Title
-    await expect(page).toFill('#title', 'Draft Product');
+    await expect(page).toFillElement('#title', 'Draft Product');
     // Click "Save Draft" button.
     await page.evaluate((selector) => document.querySelector(selector).click(), '#save-post');
     // Wait for page to reload.
     await page.waitForNavigation({ waitUntil: 'load' });
     // Verify new page saved.
-    await expect(page).toMatchElement('#wpbody-content > div.wrap > h1', 'Edit product');
-    await expect(page).toMatchElement('#title', 'Draft Product');
-    await expect(page).toMatch('Product draft updated.');
+    await expect(page).toElementEquals('#wpbody-content > div.wrap > h1', 'Edit product');
+    await expect(page).toElementEquals('#title', 'Draft Product');
+    await expect(page).toIncludes('Product draft updated.');
   });
   it('Can create a new published product', async () => {
-    expect.assertions(4);
+    expect.assertions(5);
 
     // Enter a Product Title
-    await expect(page).toFill('#title', 'Published Product');
+    await expect(page).toFillElement('#title', 'Published Product');
     // Click "Publish" button.
     await page.evaluate((selector) => document.querySelector(selector).click(), '#publish');
     // Wait for page to reload.
     await page.waitForNavigation({ waitUntil: 'load' });
     // Verify new page saved.
-    await expect(page).toMatchElement('#wpbody-content > div.wrap > h1', 'Edit product');
-    await expect(page).toMatchElement('#title', 'Published Product');
+    await expect(page).toElementEquals('#wpbody-content > div.wrap > h1', 'Edit product');
+    await expect(page).toElementEquals('#title', 'Published Product');
+    await expect(page).toIncludes('Product draft updated.');
     await expect(page).toMatch('Product published.');
   });
   it('Page load correctly', async () => {
     expect.assertions(3);
 
     // Make sure "CopyCraft" button exist on the page.
-    await expect(page).toMatchElement('#wp-content-wrap .copycraft-open-modal-button', 'CopyCraft');
+    await expect(page).toElementEquals('#wp-content-wrap .copycraft-open-modal-button', 'CopyCraft');
 
     // Click "CopyCraft" button in the main description editor.
     await page.evaluate(
@@ -51,9 +52,9 @@ describe('Product Management', () => {
     await page.waitForSelector('#TB_window');
 
     // Modal Title.
-    await expect(page).toMatchElement('#TB_window #TB_ajaxWindowTitle', 'CopyCraft');
+    await expect(page).toElementEquals('#TB_window #TB_ajaxWindowTitle', 'CopyCraft');
     // Loading message displays while AJAX call is made.
-    await expect(page).toMatchElement('#copycraft-modal-contents p.loading', 'Generating description, please wait ...');
+    await expect(page).toElementEquals('#copycraft-modal-contents p.loading', 'Generating description, please wait ...');
   });
   it('Modal displays error message when adding an empty new product', async () => {
     expect.assertions(5);
@@ -69,20 +70,20 @@ describe('Product Management', () => {
 
     // Verify error message is shown and buttons are not shown.
     await page.waitForSelector('#copycraft-modal-contents p.error');
-    await expect(page).toMatchElement(
+    await expect(page).toElementEquals(
       '#copycraft-modal-contents p.error',
       'Please enter a product name and try again.'
     );
-    await expect(page).not.toMatchElement('#replace');
-    await expect(page).not.toMatchElement('#insert');
-    await expect(page).not.toMatchElement('#refresh');
-    await expect(page).not.toMatchElement('#discard');
+    await expect(page).not.toHasElement('#replace');
+    await expect(page).not.toHasElement('#insert');
+    await expect(page).not.toHasElement('#refresh');
+    await expect(page).not.toHasElement('#discard');
   });
   it('Modal displays and ajax request running', async () => {
     expect.assertions(2);
 
     // Enter a Product Title
-    await expect(page).toFill('#title', 'A new Product');
+    await expect(page).toFillElement('#title', 'A new Product');
     // Click "CopyCraft" button in the main description editor.
     await page.evaluate(
       (selector) => document.querySelector(selector).click(),
@@ -104,7 +105,7 @@ describe('Product Management', () => {
     expect.assertions(2);
 
     // Enter a Product Title
-    await expect(page).toFill('#title', 'A new Product');
+    await expect(page).toFillElement('#title', 'A new Product');
     // Click "CopyCraft" button in the main description editor.
     await page.evaluate(
       (selector) => document.querySelector(selector).click(),
@@ -116,7 +117,7 @@ describe('Product Management', () => {
 
     // Verify error message is shown and buttons are not shown.
     await page.waitForSelector('#copycraft-modal-contents p.error');
-    await expect(page).toMatchElement(
+    await expect(page).toElementEquals(
       '#copycraft-modal-contents p.error',
       'Please enter a product name and try agadadsvavdssain.'
     );

--- a/tests/expect-matchers.js
+++ b/tests/expect-matchers.js
@@ -50,12 +50,12 @@ async function toElementEquals (page, selector, expectedText) {
   elementText = elementText.trim();
   if (elementText === expectedText) {
     return {
-      message: () => `expected text for "${selector}" not to be equal to "${expectedText}"`,
+      message: () => `expected text for "${selector}" not to be equal to "${expectedText}".`,
       pass: true
     };
   } else {
     return {
-      message: () => `expected text for "${selector}" to be equal to "${expectedText}"`,
+      message: () => `expected text for "${selector}" to be equal to "${expectedText}". Found "${elementText}" instead.`,
       pass: false
     };
   }
@@ -83,19 +83,20 @@ async function toIncludes (page, expectedText) {
 }
 
 /**
- * Expect an element to be filled with the given text.
+ * Expect an input element to be filled with the given text.
  *
- * @param {*} page Puppeteer page object.
  * @param {*} selector The CSS selector for the element.
  * @param {*} text The text to fill the element with.
  */
 async function toFillElement (page, selector, text) {
   const element = await getElement(page, selector);
 
-  await element.press('Delete');
+  // Clear all input text as per https://evanhalley.dev/post/clearing-input-field-puppeteer/
+  await element.click({ clickCount: 3 });
+  await element.press('Backspace');
   await element.type(text);
 
-  await toElementEquals(page, selector, text);
+  return await toElementEquals(page, selector, text);
 }
 
 module.exports = {

--- a/tests/expect-matchers.js
+++ b/tests/expect-matchers.js
@@ -12,12 +12,12 @@ async function getElement (page, selector) {
 }
 
 /**
- * Expect an element to exist.
+ * Expect an element to exist on the page.
  *
  * @param {*} selector
  * @returns
  */
-async function toHasElement (page, selector) {
+async function toHaveElement (page, selector) {
   const element = await page.$(selector);
   if (element !== null) {
     return {
@@ -33,7 +33,7 @@ async function toHasElement (page, selector) {
 }
 
 /**
- * Expect an element text or value to equal the expected text.
+ * Expect an element to exist with the specified text or value.
  *
  * @param {*} selector The CSS selector for the element.
  * @param {*} expectedText The expected text or value.
@@ -66,7 +66,7 @@ async function toElementEquals (page, selector, expectedText) {
  *
  * @param {*} expectedText The text to search for.
  */
-async function toIncludes (page, expectedText) {
+async function toIncludeText (page, expectedText) {
   // Get the page as text via Puppeteer.
   const pageText = await page.evaluate(() => document.documentElement.textContent);
   if (pageText.includes(expectedText)) {
@@ -102,6 +102,6 @@ async function toFillElement (page, selector, text) {
 module.exports = {
   toElementEquals,
   toFillElement,
-  toHasElement,
-  toIncludes
+  toHaveElement,
+  toIncludeText
 };

--- a/tests/expect-matchers.js
+++ b/tests/expect-matchers.js
@@ -1,0 +1,100 @@
+/**
+ * @param {string} selector The CSS selector for the element.
+ * @returns {ElementHandle} The element handle.
+ */
+
+async function getElement (page, selector) {
+  const element = await page.$(selector);
+  if (element === null) {
+    throw new Error(`Element ${selector} not found`);
+  }
+  return element;
+}
+
+/**
+ * Expect an element to exist.
+ *
+ * @param {*} selector
+ * @returns
+ */
+async function toHasElement (page, selector) {
+  const element = await page.$(selector);
+  if (element !== null) {
+    return {
+      message: () => `expected "${selector}" not to be find in the page`,
+      pass: true
+    };
+  } else {
+    return {
+      message: () => `expected "${selector}" to be find in the page`,
+      pass: false
+    };
+  }
+}
+
+/**
+ * Expect an element text to equals the expected text.
+ *
+ * @param {*} selector The CSS selector for the element.
+ * @param {*} expectedText The expected text.
+ */
+async function toElementEquals (page, selector, expectedText) {
+  const element = await getElement(page, selector);
+  // Get the text from the element via Puppeteer
+  const elementText = await page.evaluate((el) => el.textContent, element);
+  if (elementText === expectedText) {
+    return {
+      message: () => `expected text for "${selector}" not to be equal to "${expectedText}"`,
+      pass: true
+    };
+  } else {
+    return {
+      message: () => `expected text for "${selector}" to be equal to "${expectedText}"`,
+      pass: false
+    };
+  }
+}
+
+/**
+ * Expect the page to include the given text.
+ *
+ * @param {*} expectedText The text to search for.
+ */
+async function toIncludes (page, expectedText) {
+  // Get the page as text via Puppeteer.
+  const pageText = await page.evaluate(() => document.documentElement.textContent);
+  if (pageText.includes(expectedText)) {
+    return {
+      message: () => `expected "${expectedText}" to be not found in the page`,
+      pass: true
+    };
+  } else {
+    return {
+      message: () => `expected "${expectedText}" to be  found in the page`,
+      pass: false
+    };
+  }
+}
+
+/**
+ * Expect an element to be filled with the given text.
+ *
+ * @param {*} page Puppeteer page object.
+ * @param {*} selector The CSS selector for the element.
+ * @param {*} text The text to fill the element with.
+ */
+async function toFillElement (page, selector, text) {
+  const element = await getElement(page, selector);
+
+  await element.press('Delete');
+  await element.type(text);
+
+  await toElementEquals(page, selector, text);
+}
+
+module.exports = {
+  toElementEquals,
+  toFillElement,
+  toHasElement,
+  toIncludes
+};

--- a/tests/expect-matchers.js
+++ b/tests/expect-matchers.js
@@ -42,7 +42,7 @@ async function toElementEquals (page, selector, expectedText) {
   const element = await getElement(page, selector);
   // Get the text from the element via Puppeteer
   let elementText = await (await element.getProperty('textContent')).jsonValue();
-  if (typeof elementText === 'undefined' || elementText === null || elementText === '') {
+  if (!elementText) {
     // No text for this element, get the value from the element via Puppeteer.
     elementText = await (await element.getProperty('value')).jsonValue();
   }

--- a/tests/expect-matchers.js
+++ b/tests/expect-matchers.js
@@ -33,15 +33,21 @@ async function toHasElement (page, selector) {
 }
 
 /**
- * Expect an element text to equals the expected text.
+ * Expect an element text or value to equal the expected text.
  *
  * @param {*} selector The CSS selector for the element.
- * @param {*} expectedText The expected text.
+ * @param {*} expectedText The expected text or value.
  */
 async function toElementEquals (page, selector, expectedText) {
   const element = await getElement(page, selector);
   // Get the text from the element via Puppeteer
-  const elementText = await page.evaluate((el) => el.textContent, element);
+  let elementText = await (await element.getProperty('textContent')).jsonValue();
+  if (typeof elementText === 'undefined' || elementText === null || elementText === '') {
+    // No text for this element, get the value from the element via Puppeteer.
+    elementText = await (await element.getProperty('value')).jsonValue();
+  }
+  // Trim whitespace.
+  elementText = elementText.trim();
   if (elementText === expectedText) {
     return {
       message: () => `expected text for "${selector}" not to be equal to "${expectedText}"`,

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,3 @@
+const matchers = require('./expect-matchers');
+
+expect.extend(matchers);


### PR DESCRIPTION
Some of our current expectations weren't working as intended. For example, [this expectation](https://github.com/OM4/CopyCraft/blob/a620297e7d0248fcbbc509b33f804e384ca788da/tests/e2e/products.test.js#L119), as well as others.

This PR introduces our own [Jest Matchers](https://jestjs.io/docs/expect#expectextendmatchers) that work as expected with Puppeteer.

These replace the [standard ones that come with jest-puppeteer](https://github.com/smooth-code/jest-puppeteer/blob/master/packages/expect-puppeteer/README.md#api), such as .`toMatchElement()`, `.toFill()`, `.toMatch()`, etc.

Thank you to @om4csaba for architecting and designing this solution and allowing me to [finish it off with these commits](1ef3408a00ce40021db9f403bbbe468ff5148ef5...88750d035d32c84f6dc194d8bb6ec325b9fbc708) :)

