### PR TITLE
Declare compatibility with WooCommerce High-Performance Order Storage (HPOS)

### DIFF
--- a/copycraft.php
+++ b/copycraft.php
@@ -70,6 +70,20 @@ class Plugin {
 		$this->container->delegate( new ReflectionContainer( true ) );
 
 		add_action( 'init', array( $this, 'admin_init' ) );
+
+		/**
+		 * Declare compatibility with WooCommerce High-Performance Order Storage (HPOS).
+		 *
+		 * @link https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book
+		 */
+		add_action(
+			'before_woocommerce_init',
+			function() {
+				if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+					\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+				}
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
Suggested here: https://wordpress.org/support/topic/please-add-support-for-hpos-cot/

CopyCraft does not interact with Orders (only Products), so it is compatible.